### PR TITLE
add mac prereq setup instruction

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,9 +27,13 @@ web-back-0             Burstable    Running
 
 ## Install kubectl-custom-cols
 
-### Manualy
+### Prereqs
 
-* dowload the latest release
+If you're on Mac OS X, you may need to first run `brew install coreutils` to get the `realpath` function.
+
+### Manually
+
+* download the latest release
 * copy `kubectl-custom-cols` script and the `templates` folder together, somewhere in your PATH
 
 ### Via krew


### PR DESCRIPTION
This is a super cool plugin!

I wasn't able to get it working until I ran `brew install coreutils`, so I added that to the README for any other Mac users.